### PR TITLE
Display actual shard name instead of generic label

### DIFF
--- a/spec/frame_spec.cr
+++ b/spec/frame_spec.cr
@@ -8,8 +8,14 @@ describe "Frame parsing" do
     frame = frame_for("from usr/crystal/frame_spec.cr:6:7 in '->'")
     frame.label.should eq("crystal")
 
+    frame = frame_for("from lib/exception_page/spec/frame_spec.cr:6:7 in '->'")
+    frame.label.should eq("exception_page")
+
+    frame = frame_for("from lib/exception_page/frame_spec.cr:6:7 in '->'")
+    frame.label.should eq("exception_page")
+
     frame = frame_for("from lib/frame_spec.cr:6:7 in '->'")
-    frame.label.should eq("shard")
+    frame.label.should eq("app")
 
     frame = frame_for("from src/frame_spec.cr:6:7 in '->'")
     frame.label.should eq("app")

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -8,7 +8,7 @@ include LuckyFlow::Expectations
 
 server = TestServer.new(3002)
 
-LuckyFlow.configure do
+LuckyFlow.configure do |settings|
   settings.base_uri = "http://localhost:3002"
   settings.stop_retrying_after = 40.milliseconds
 end

--- a/src/exception_page/frame.cr
+++ b/src/exception_page/frame.cr
@@ -49,12 +49,10 @@ struct ExceptionPage::Frame
 
   def label : String
     case file
-    when .includes?("/crystal/")
+    when .includes?("/crystal/"), .includes?("/crystal-lang/")
       "crystal"
-    when .includes?("/crystal-lang/")
-      "crystal"
-    when .includes?("lib/")
-      "shard"
+    when /lib\/(?<name>[^\/]+)\/.+/
+      $~["name"]
     else
       "app"
     end


### PR DESCRIPTION
This PR replaces generic _shard_ label with the actual shard name, making immediately clear which callstack line comes from where.