### PR TITLE
Avoid using deprecated HTTP::Request#host_with_port

### DIFF
--- a/src/exception_page.cr
+++ b/src/exception_page.cr
@@ -39,7 +39,7 @@ abstract class ExceptionPage
     @headers = context.response.headers.to_h
     @method = context.request.method
     @path = context.request.path
-    @url = "#{context.request.host_with_port}#{context.request.path}"
+    @url = "#{context.request.headers["Host"]?}#{context.request.path}"
     @query = context.request.query_params.to_s
     @session = context.response.cookies.to_h
   end


### PR DESCRIPTION
Although this is mainly needed for warning free ~~1.0.0-dev~~ 0.36.0 support, the PR can be applied safely today.

Ref: https://github.com/crystal-lang/crystal/pull/10029