### PR TITLE
Release v0.1.5

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: exception_page
-version: 0.1.4
+version: 0.1.5
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>


### PR DESCRIPTION
bump version for next release. This is mainly just for crystal 1.0 compatibility. 