### PR TITLE
Centering logos on the exception page

### DIFF
--- a/src/exception_page/exception_page.ecr
+++ b/src/exception_page/exception_page.ecr
@@ -109,11 +109,11 @@ monospace_font = "menlo, consolas, monospace"
         display: block;
         height: 64px;
         width: 100%;
-        background-size: auto 100%;
+        background-size: 100%;
         <%- if styles.logo_uri -%>
         background-image: url("<%= styles.logo_uri %>");
         <%- end -%>
-        background-position: right 0;
+        background-position: center center;
         background-repeat: no-repeat;
     }
 


### PR DESCRIPTION
Fixes #24

In the case of the Lucky logo not being a perfect square, the left side would be clipped. Since the logos are background images, this PR makes them center within the block, and makes them full size.