### PR TITLE
bump version to fix shard warning

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: exception_page
-version: 0.2.1
+version: 0.2.2
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>


### PR DESCRIPTION
Fixes #30

There's no change other than this will get rid of that version mismatch warning that shards throws.