### PR TITLE
Updating failing specs and dependencies to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         crystal_version: [latest]
-        include:
-          - os: ubuntu-latest
-            crystal_version: 1.6.2
     runs-on: ${{ matrix.os }}
     continue-on-error: false
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,45 +1,45 @@
-name: CI
+name: Exception Page CI
 
 on:
-  pull_request:
   push:
     branches: [master]
-  schedule:
-    - cron: "0 3 * * 1" # Every monday at 3 AM
+  pull_request:
+    branches: "*"
 
 jobs:
-  test:
+  check_format:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - name: Download source
+        uses: actions/checkout@v3
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Install shards
+        run: shards install
+      - name: Format
+        run: crystal tool format --check
+      - name: Lint
+        run: ./bin/ameba
+  specs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        crystal: [0.36.1, latest, nightly]
+        os: [ubuntu-latest, windows-latest]
+        crystal_version: [latest]
+        include:
+          - os: ubuntu-latest
+            crystal_version: 1.6.2
     runs-on: ${{ matrix.os }}
-
+    continue-on-error: false
     steps:
-      - name: Install Crystal
-        uses: oprypin/install-crystal@v1
+      - uses: actions/checkout@v3
+      - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: ${{ matrix.crystal }}
-
-      - name: Install ChromeDriver
-        run: |
-          sudo apt-get update
-          sudo apt-get -yqq install chromium-chromedriver
-
-      - name: Download source
-        uses: actions/checkout@v2
-
+          crystal: ${{ matrix.crystal_version }}
       - name: Install dependencies
-        run: shards install
-        env:
-          SHARDS_OPTS: --ignore-crystal-version
-
-      - name: Run specs
+        run: shards install --skip-postinstall --skip-executables
+      - name: Run tests
         run: crystal spec
-
-      - name: Check formatting
-        run: crystal tool format --check
-
-      - name: Run ameba linter
-        run: bin/ameba

--- a/shard.yml
+++ b/shard.yml
@@ -19,6 +19,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 1.4.3
 
-crystal: ">= 1.4.0"
+crystal: ">= 1.8.0"
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -9,16 +9,16 @@ authors:
 dependencies:
   backtracer:
     github: Sija/backtracer.cr
-    version: ~> 1.2.1
+    version: ~> 1.2.2
 
 development_dependencies:
   lucky_flow:
     github: luckyframework/lucky_flow
-    version: ~> 0.7.3
+    version: ~> 0.9.0
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.3
+    version: ~> 1.4.3
 
-crystal: ">= 0.33.0"
+crystal: ">= 1.4.0"
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
 development_dependencies:
   lucky_flow:
     github: luckyframework/lucky_flow
-    version: ~> 0.9.0
+    version: ~> 0.9.1
   ameba:
     github: crystal-ameba/ameba
     version: ~> 1.4.3

--- a/spec/exception_page_spec.cr
+++ b/spec/exception_page_spec.cr
@@ -17,10 +17,10 @@ class ErrorDebuggingFlow < LuckyFlow
   end
 
   def should_have_information_for_debugging
-    el("@exception-title", text: "Something went very wrong").should be_on_page
-    el("@code-frames", text: "test_server.cr").should be_on_page
+    current_page.should have_element("@exception-title", text: "Something went very wrong")
+    current_page.should have_element("@code-frames", text: "test_server.cr")
     click("@see-raw-error-message")
-    el("@raw-error-message").should be_on_page
+    current_page.should have_element("@raw-error-message")
   end
 
   def show_all_frames
@@ -29,6 +29,11 @@ class ErrorDebuggingFlow < LuckyFlow
 
   def should_be_able_to_view_other_frames
     el("@code-frame-file", "server.cr").click
-    el("@code-frame-summary", text: "->").should be_on_page
+    current_page.should have_element("@code-frame-summary", text: "->")
+  end
+
+  # A shim used for readibility in tests
+  private def current_page
+    self
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,4 @@
+require "spec"
 require "http"
 require "lucky_flow"
 require "../src/exception_page"
@@ -5,25 +6,16 @@ require "./support/*"
 
 include LuckyFlow::Expectations
 
-server = TestServer.new
-
 LuckyFlow.configure do |settings|
-  settings.base_uri = "http://#{server.addr}"
+  settings.base_uri = "http://local.test"
   settings.stop_retrying_after = 40.milliseconds
-
-  # Enable this setting to watch the browser
-  # settings.driver = LuckyFlow::Drivers::Chrome
 end
 
-spawn do
-  server.listen
+LuckyFlow::Registry.register :webless do
+  LuckyFlow::Webless::Driver.new(TestHandler.new)
 end
 
-at_exit do
-  LuckyFlow.shutdown
-  server.close
-end
+LuckyFlow.default_driver = ENV.fetch("LUCKYFLOW_DRIVER", "webless")
+LuckyFlow::Spec.setup
 
 Habitat.raise_if_missing_settings!
-
-require "spec"

--- a/spec/support/test_handler.cr
+++ b/spec/support/test_handler.cr
@@ -1,0 +1,16 @@
+class TestHandler
+  include HTTP::Handler
+
+  def call(context)
+    if context.request.resource == "/favicon.ico"
+      context.response.print ""
+    else
+      begin
+        raise CustomException.new("Something went very wrong")
+      rescue e : CustomException
+        context.response.content_type = "text/html"
+        context.response.print MyApp::ExceptionPage.for_runtime_exception(context, e).to_s
+      end
+    end
+  end
+end

--- a/spec/support/test_server.cr
+++ b/spec/support/test_server.cr
@@ -1,22 +1,10 @@
 class TestServer
   getter addr : Socket::IPAddress
 
-  delegate :listen, :close,
-    to: @server
+  delegate :listen, :close, to: @server
 
   def initialize(port : Int32? = nil)
-    @server = HTTP::Server.new do |context|
-      if context.request.resource == "/favicon.ico"
-        context.response.print ""
-      else
-        begin
-          raise CustomException.new("Something went very wrong")
-        rescue e : CustomException
-          context.response.content_type = "text/html"
-          context.response.print MyApp::ExceptionPage.for_runtime_exception(context, e).to_s
-        end
-      end
-    end
+    @server = HTTP::Server.new([TestHandler.new])
     if port
       @addr = @server.bind_tcp(port: port)
     else

--- a/src/exception_page/exception_page.ecr
+++ b/src/exception_page/exception_page.ecr
@@ -694,7 +694,7 @@
                 <label class="stack-trace-heading" for="show-all-frames">Show all frames</label>
 
                 <% @frames.each_with_index do |frame, index| %>
-                  <div class="code-snippets-wrapper">
+                  <div class="code-snippets-wrapper" flow-id="code-frame-file">
                     <input type="radio" id="trace<%= index %>" name="stack-trace-list" <%= index == 0 ? "checked" : "" %> >
                     <label for="trace<%= index %>" class="stack-trace-item -<%= css_class_for_frame(frame) %>">
                       <%- path = frame.relative_path || frame.path -%>


### PR DESCRIPTION
Closes #36 
Fixes #38 
Fixes #39 

This PR does a few things:

* Update the CI to remove the cron schedule. Github will disable it if there's no activity after a bit, and this shard isn't updated often enough to keep that going
* Update LuckyFlow to the latest version and setup Webless. The specs no long need a chromedriver to run which allows them to run a lot faster with less dependencies
* Updated the CI to include windows so we can start testing this against windows.
* I set the min Crystal version to 1.4, though I imagine we need at least 1.6 or latest for all the Window stuff..