### PR TITLE
Decouple from `HTTP::Server::Context`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class MyErrorHandler
       raise SomeError.new("Something went wrong")
     rescue e
       context.response.status_code = 500
-      context.response.print MyApp::ExceptionPage.for_runtime_exception(context, e).to_s
+      context.response.print MyApp::ExceptionPage.new context, e
     end
   end
 ```

--- a/spec/exception_page_spec.cr
+++ b/spec/exception_page_spec.cr
@@ -16,6 +16,10 @@ describe ExceptionPage do
     flow.view_error_page
     flow.should_have_additional_message_lines
   end
+
+  it "allows instantiating one manually" do
+    MyApp::ExceptionPage.new Exception.new("Oh noes"), "SEARCH", "/users", :im_a_teapot
+  end
 end
 
 class ErrorDebuggingFlow < LuckyFlow

--- a/spec/support/test_handler.cr
+++ b/spec/support/test_handler.cr
@@ -10,14 +10,14 @@ class TestHandler
         raise CustomException.new("Something went very wrong\nBut wait, there's more!")
       rescue e : CustomException
         context.response.content_type = "text/html"
-        context.response.print MyApp::ExceptionPage.for_runtime_exception(context, e)
+        context.response.print MyApp::ExceptionPage.new context, e
       end
     else
       begin
         raise CustomException.new("Something went very wrong")
       rescue e : CustomException
         context.response.content_type = "text/html"
-        context.response.print MyApp::ExceptionPage.for_runtime_exception(context, e)
+        context.response.print MyApp::ExceptionPage.new context, e
       end
     end
   end

--- a/src/exception_page.cr
+++ b/src/exception_page.cr
@@ -61,9 +61,9 @@ abstract class ExceptionPage
     @path : String,
     @status : HTTP::Status,
     title : String? = nil,
-    @params : URI::Params? = nil,
-    @headers : HTTP::Headers? = nil,
-    @cookies : HTTP::Cookies? = nil,
+    @params : URI::Params = URI::Params.new,
+    @headers : HTTP::Headers = HTTP::Headers.new,
+    @cookies : HTTP::Cookies = HTTP::Cookies.new,
     message : String? = nil,
     url : String? = nil
   )

--- a/src/exception_page/exception_page.ecr
+++ b/src/exception_page/exception_page.ecr
@@ -806,7 +806,7 @@
 
             <dl>
                 <dt>Query string:</dt>
-                <dd class="code-quote"><%= HTML.escape(@query) %></dd>
+                <dd class="code-quote"><%= HTML.escape(@params.to_s) %></dd>
             </dl>
         </details>
 
@@ -820,13 +820,13 @@
             <% end %>
         </details>
 
-        <% if (session = @session) && !session.empty? %>
+        <% if (cookies = @cookies) && !cookies.empty? %>
         <details class="conn-details">
             <summary>Session</summary>
-            <% session.each do |key, value| %>
+            <% cookies.each do |cookie| %>
             <dl>
-                <dt><%= HTML.escape(key) %></dt>
-                <dd><pre><%= HTML.escape(value.inspect) %></pre></dd>
+                <dt><%= HTML.escape(cookie.name) %></dt>
+                <dd><pre><%= HTML.escape(cookie.value.inspect) %></pre></dd>
             </dl>
             <% end %>
         </details>


### PR DESCRIPTION
This PR does a bit of a refactor to decouple an exception page from a `HTTP::Server::Context`, making it more flexible. E.g. for use in frameworks where that object is not directly available, but all the required information is.

Opening this is a draft to allow time for discussion before moving forward:

* Cookies, headers, and params are now proper `HTTP::*` types vs hashes
* Added `HTTP::Status` as an ivar
* Dropped `@query` ivar in favor of `@params`
  * `@query` was simply `@params.to_s`
* Constructors changed a bit
  * Dropped `.for_runtime_exception` in favor of `.new`
  * Dropped an overload with the context, message, title, and frames

Resolves #48 