### PR TITLE
Fix overflowing filename

### DIFF
--- a/src/exception_page/exception_page.ecr
+++ b/src/exception_page/exception_page.ecr
@@ -274,9 +274,8 @@
     .frame-info > .file {
         display: inline-block;
         vertical-align: top;
-        width: calc(100%);
-        overflow: hidden;
-        text-overflow: ellipsis;
+        width: 100%;
+        overflow: auto hidden;
     }
 
     @media (max-width: 768px) {

--- a/src/exception_page/exception_page.ecr
+++ b/src/exception_page/exception_page.ecr
@@ -267,8 +267,16 @@
     .frame-info > .meta,
     .frame-info > .file {
         padding: 12px 16px;
-        white-space: no-wrap;
+        white-space: nowrap;
         font-size: <%= 1.2 ** -1 %>em;
+    }
+
+    .frame-info > .file {
+        display: inline-block;
+        vertical-align: top;
+        width: calc(100%);
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     @media (max-width: 768px) {


### PR DESCRIPTION
Before:

![image](https://github.com/crystal-loot/exception_page/assets/988/fff8be86-32bb-4d1f-931a-81001e06fc17)

After:

<img width="662" alt="image" src="https://github.com/crystal-loot/exception_page/assets/988/789d72cd-974d-41d8-a095-a5847f61d096">
